### PR TITLE
Nu med mere UTF-8!

### DIFF
--- a/includes/cronjob.py
+++ b/includes/cronjob.py
@@ -74,7 +74,7 @@ class MailTask(object):
 			print subject
 			print s
 		else:
-			msg = MIMEText(s.encode('utf-8'))
+			msg = MIMEText(s.encode('utf-8'), 'plain', 'utf-8')
 			msg['Subject'] = subject
 			msg['From'] = 'boss@dikurevy.dk'
 			msg['Reply-To'] = 'revy@dikurevy.dk'


### PR DESCRIPTION
Før havde alle emails headeren:

    Content-Type: text/plain; charset="us-ascii"

Og nu bør de have headeren:

    Content-Type: text/plain; charset="utf-8"